### PR TITLE
Document and enforce minimal version for Pillow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Backends are divided in 2 types:
 
 Vignette currently has thumbnail/metadata backends supporting:
 
-* Python Imaging Library (PIL)
+* Python Imaging Library (PIL), e.g. `Pillow <https://python-pillow.org/>`_ >= 6.0
 * PyQt
 * PythonMagick
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ email = "dev@indigo.re"
 
 [project.optional-dependencies]
 pillow = [
-    "Pillow",
+    "Pillow>=6.0",
 ]
 pythonmagick = [
     "PythonMagick",

--- a/vignette/__init__.py
+++ b/vignette/__init__.py
@@ -554,7 +554,10 @@ class PilBackend(MetadataBackend, ThumbnailBackend):
 		try:
 			import PIL.Image
 			import PIL.PngImagePlugin
+			import PIL.ImageOps
 		except ImportError:
+			return False
+		if not hasattr(PIL.ImageOps, 'exif_transpose'):
 			return False
 
 		cls.mod = PIL.Image


### PR DESCRIPTION
Document and enforce the minimal required version on Pillow for the PIL backend:

- Document the minimal version on Pillow in machine readable way in `pyproject.toml`,
- Document the minimal version on Pillow in human readable way in the README,
- Enforce the the minimal version on Pillow in the implementation, e.g. return `False` from `PilBackend.is_available()` if the requirement is not met.

Close #6.